### PR TITLE
Update for Patch 6.1 (API 6 and KeyNotFoundException Fix)

### DIFF
--- a/GentleTouch/GentleTouch.cs
+++ b/GentleTouch/GentleTouch.cs
@@ -151,9 +151,9 @@ namespace GentleTouch
             //NOTE (Chiv): Signature from :
             // https://github.com/Caraxi/SimpleTweaksPlugin/blob/078c48947fce3578d631cd2de50245005aba8fdd/Helper/Common.cs
             const string actionManagerSignature = "E8 ?? ?? ?? ?? 33 C0 E9 ?? ?? ?? ?? 8B 7D 0C";
-            //NOTE (Chiv): Signature from :
-            // https://github.com/Caraxi/SimpleTweaksPlugin/blob/078c48947fce3578d631cd2de50245005aba8fdd/GameStructs/ActionManager.cs
-            const string getActionCooldownSlotSignature = "E8 ?? ?? ?? ?? 0F 57 FF 48 85 C0";
+            // NOTE (Chiv): Signature from :
+            // https://github.com/aers/FFXIVClientStructs/blob/c015150c5122f68cbc32aef14ce591b2cdf410ed/FFXIVClientStructs/FFXIV/Client/Game/ActionManager.cs#L36
+            const string getActionCooldownSlotSignature = "40 53 48 83 EC ?? 48 63 DA 85 D2";
 
             #endregion
             

--- a/GentleTouch/GentleTouch.csproj
+++ b/GentleTouch/GentleTouch.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DalamudPackager" Version="2.1.5" />
+    <PackageReference Include="DalamudPackager" Version="2.1.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GentleTouch/GentleTouch.yaml
+++ b/GentleTouch/GentleTouch.yaml
@@ -1,6 +1,5 @@
 ﻿name: GentleTouch
 author: Chivalrik
-DalamudApiLevel: 5
 description: |-
   You need to configure patterns and triggers before it will work, 
   open the configuration window to do that. 


### PR DESCRIPTION
I can see now why it this plugin didn't get updated for Patch 6.1. It took me quite a while to track down the new signature needed that no longer worked. I ended up finding it by tracking which end user tweaks in Simple Tweaks used an "ActionManager" that existed in the 'main' branch, and then using Visual Studio, ctrl+click to find where the ActionManager was being defined, and it turns out that Caraxi switched to using an external structs library (as you can see in the comment in my commit).

After I changed the signature and updated to API 6, I built it and it seems to be working for me in game right now.

I haven't fully tested everything yet, but I think it's good enough to be published a testing version.